### PR TITLE
add url for talk engine com rails

### DIFF
--- a/_posts/2016-03-09-Engines-com-Rails.md
+++ b/_posts/2016-03-09-Engines-com-Rails.md
@@ -6,5 +6,5 @@ date: 2016-03-09 11:39:01
 duration: 15:20
 tags: [ rails ]
 img: /assets/image/speakers/eduardo-maia.jpg
-link: 
+link: https://www.youtube.com/watch?v=IQzo4OV5PBw
 ---


### PR DESCRIPTION
### **CHANGELOG** :memo:

<!-- Se for bugfix, altere CHANGELOG para BUGFIX. -->
1. talk about 'engines com rails' was url none
