### PR TITLE
Add Sergio Lopes' talk at BrazilJS 2016

### DIFF
--- a/_posts/2016-10-24-Sergio-Lopes-Desafios-praticos-de-performance-Web-BrazilJS-Conf-2016.md
+++ b/_posts/2016-10-24-Sergio-Lopes-Desafios-praticos-de-performance-Web-BrazilJS-Conf-2016.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: Sérgio Lopes - Desafios práticos de performance Web - BrazilJS Conf 2016
+speakers: Sérgio Lopes
+date: 2016-10-24 19:02:43
+duration: 36:56
+tags: [ desempenho, css ]
+img: /assets/image/speakers/sergiolopes.jpg
+link: https://www.youtube.com/watch?v=EMCBd3kw4zs
+---


### PR DESCRIPTION
### **CHANGELOG** :memo:
1. Add Sergio Lopes' talk at BrazilJS Conf 2016
